### PR TITLE
Fix XML parser dependency for title index refresh

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
   "beautifulsoup4>=4.12.3",
+  "lxml>=5.4.0",
   "openai>=1.75.0",
   "requests>=2.32.3",
 ]

--- a/src/fmi_report_guard/scraper.py
+++ b/src/fmi_report_guard/scraper.py
@@ -6,7 +6,7 @@ from html import unescape
 from urllib.parse import urlparse
 
 import requests
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, FeatureNotFound
 
 from .models import ReportCard, ReportPage
 from .title_index import make_indexed_title
@@ -140,7 +140,10 @@ class FMIClient:
         for sitemap_url in REPORT_SITEMAP_URLS:
             response = self.session.get(sitemap_url, timeout=self.timeout_seconds)
             response.raise_for_status()
-            soup = BeautifulSoup(response.text, "xml")
+            try:
+                soup = BeautifulSoup(response.text, "xml")
+            except FeatureNotFound:
+                soup = BeautifulSoup(response.text, "html.parser")
             for node in soup.find_all("loc"):
                 url = normalize_text(node.get_text(" ", strip=True))
                 if not url or url in seen_urls:


### PR DESCRIPTION
## Summary
- add `lxml` as runtime dependency for BeautifulSoup XML parsing
- fall back to `html.parser` if XML backend unavailable
- prevent monitor runs from failing during title index refresh

## Root Cause
GitHub Actions runner hit `bs4.exceptions.FeatureNotFound` because code requested `BeautifulSoup(..., "xml")`, but the XML parser backend was not installed.

## Verification
- `pytest -q` -> `19 passed`
- local live title index fetch succeeded

## Impact
Before this fix, the monitor workflow could fail before auditing any new FMI reports, so stale GitHub issues did not imply clean reports.
