### PR TITLE
Add LLM benchmark judgment API

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,12 @@ python -m fmi_report_guard.sync_digest
 - GitHub Actions schedules are best-effort. A `*/10` cron does not guarantee an exact 10-minute wall-clock run.
 - The monitor is tuned to avoid noise. If the model is not highly confident, it should return no findings.
 - Do not paste your API key into code or issues. Use the GitHub secret only.
+
+## Benchmark checker web app
+
+The Render Blueprint deploys:
+
+- `fmi-benchmark-checker`: static frontend for writers.
+- `fmi-benchmark-api`: Python API for LLM relationship judgment.
+
+Set `OPENAI_API_KEY` in the Render environment for `fmi-benchmark-api`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,11 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
   "beautifulsoup4>=4.12.3",
+  "fastapi>=0.124.0",
   "lxml>=5.4.0",
   "openai>=1.75.0",
   "requests>=2.32.3",
+  "uvicorn>=0.38.0",
 ]
 
 [project.optional-dependencies]

--- a/render.yaml
+++ b/render.yaml
@@ -1,11 +1,29 @@
 services:
   - type: web
+    name: fmi-benchmark-api
+    runtime: python
+    plan: free
+    buildCommand: pip install -e .
+    startCommand: uvicorn fmi_report_guard.api:app --host 0.0.0.0 --port $PORT
+    autoDeployTrigger: commit
+    envVars:
+      - key: OPENAI_API_KEY
+        sync: false
+      - key: OPENAI_MODEL
+        value: gpt-5-mini
+      - key: ALLOWED_ORIGINS
+        value: https://fmi-benchmark-checker.onrender.com,http://localhost:5173,http://127.0.0.1:5173
+
+  - type: web
     name: fmi-benchmark-checker
     runtime: static
     rootDir: web
     buildCommand: npm run fetch-db && npm run build
     staticPublishPath: ./dist
     autoDeployTrigger: commit
+    envVars:
+      - key: VITE_LLM_API_URL
+        value: https://fmi-benchmark-api.onrender.com
     headers:
       - path: /*
         name: X-Frame-Options

--- a/src/fmi_report_guard/api.py
+++ b/src/fmi_report_guard/api.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+import os
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from openai import OpenAI
+from pydantic import BaseModel, Field
+
+
+DEFAULT_ALLOWED_ORIGINS = [
+    "https://fmi-benchmark-checker.onrender.com",
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
+]
+MAX_MATCHES = 20
+
+
+class CandidateInput(BaseModel):
+    title: str = Field(min_length=3, max_length=180)
+    estimated_year: int = Field(ge=2000, le=2100)
+    estimated_value_usd_mn: float = Field(gt=0)
+    forecast_year: int = Field(ge=2000, le=2100)
+    forecast_value_usd_mn: float = Field(gt=0)
+    cagr_percent: float = Field(ge=-50, le=200)
+
+
+class BenchmarkInput(BaseModel):
+    market_name: str = Field(min_length=3, max_length=220)
+    url: str = Field(default="", max_length=500)
+    category: str = Field(default="", max_length=160)
+    estimated_year: int = Field(ge=2000, le=2100)
+    estimated_value_usd_mn: float = Field(gt=0)
+    forecast_year: int = Field(ge=2000, le=2100)
+    forecast_value_usd_mn: float = Field(gt=0)
+    cagr_percent: float = Field(ge=-50, le=200)
+
+
+class MatchInput(BaseModel):
+    relationship_hint: str = Field(default="", max_length=80)
+    issue_hint: str = Field(default="", max_length=800)
+    recommendation_hint: str = Field(default="", max_length=800)
+    benchmark: BenchmarkInput
+
+
+class JudgeRequest(BaseModel):
+    candidate: CandidateInput
+    matches: list[MatchInput] = Field(default_factory=list, max_length=MAX_MATCHES)
+
+
+def _allowed_origins() -> list[str]:
+    configured = os.getenv("ALLOWED_ORIGINS", "")
+    if not configured.strip():
+        return DEFAULT_ALLOWED_ORIGINS
+    return [origin.strip() for origin in configured.split(",") if origin.strip()]
+
+
+app = FastAPI(title="FMI Benchmark Brain API")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_allowed_origins(),
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/health")
+def health() -> dict[str, object]:
+    return {
+        "ok": True,
+        "openai_configured": bool(os.getenv("OPENAI_API_KEY")),
+        "model": os.getenv("OPENAI_MODEL", "gpt-5-mini"),
+    }
+
+
+@app.post("/api/judge")
+def judge_market_relationship(payload: JudgeRequest) -> dict[str, object]:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise HTTPException(status_code=503, detail="OPENAI_API_KEY is not configured.")
+
+    if not payload.matches:
+        return {
+            "summary": "No benchmark candidates were found for LLM review.",
+            "should_escalate": False,
+            "judgments": [],
+        }
+
+    client = OpenAI(api_key=api_key)
+    model = os.getenv("OPENAI_MODEL", "gpt-5-mini")
+    response = client.responses.create(
+        model=model,
+        input=_build_messages(payload),
+        text={
+            "format": {
+                "type": "json_schema",
+                "name": "fmi_market_relationship_judgment",
+                "strict": True,
+                "schema": _judgment_schema(),
+            }
+        },
+    )
+
+    return json.loads(response.output_text)
+
+
+def _build_messages(payload: JudgeRequest) -> list[dict[str, str]]:
+    prompt = {
+        "task": (
+            "Judge whether the candidate market title is a parent, child, sibling, adjacent, "
+            "or unrelated market compared with each benchmark row. Then decide whether the "
+            "entered 2026 and 2036 values violate parent-child market size logic."
+        ),
+        "rules": [
+            "Do not rely only on shared words. Use market taxonomy and business scope.",
+            "A child/subset market cannot be larger than its parent market.",
+            "A parent market cannot be smaller than an existing child/subset market.",
+            "Adjacent markets, ingredients, components, technologies, channels, or end uses are not automatically parent-child.",
+            "If relationship is ambiguous, return unclear and do not create a hard violation.",
+            "Prefer false negatives over false positives.",
+            "Use USD million values exactly as provided.",
+            "Return concise editor-friendly text. No markdown.",
+        ],
+        "candidate": payload.candidate.model_dump(),
+        "candidate_unit_note": "All values are normalized to USD million.",
+        "benchmark_matches": [match.model_dump() for match in payload.matches[:MAX_MATCHES]],
+    }
+    return [
+        {
+            "role": "system",
+            "content": (
+                "You are a strict market taxonomy and sizing auditor for FMI report titles. "
+                "Your job is to reduce false parent-child alarms and catch true hierarchy violations."
+            ),
+        },
+        {"role": "user", "content": json.dumps(prompt, ensure_ascii=True)},
+    ]
+
+
+def _judgment_schema() -> dict[str, object]:
+    relationship_values = [
+        "candidate_is_child",
+        "candidate_is_parent",
+        "sibling_or_adjacent",
+        "unrelated",
+        "unclear",
+    ]
+    return {
+        "type": "object",
+        "properties": {
+            "summary": {"type": "string"},
+            "should_escalate": {"type": "boolean"},
+            "judgments": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "market_name": {"type": "string"},
+                        "url": {"type": "string"},
+                        "relationship": {"type": "string", "enum": relationship_values},
+                        "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+                        "violates_parent_child_rule": {"type": "boolean"},
+                        "issue": {"type": "string"},
+                        "control_f": {"type": "string"},
+                        "change_with": {"type": "string"},
+                        "reason": {"type": "string"},
+                    },
+                    "required": [
+                        "market_name",
+                        "url",
+                        "relationship",
+                        "confidence",
+                        "violates_parent_child_rule",
+                        "issue",
+                        "control_f",
+                        "change_with",
+                        "reason",
+                    ],
+                    "additionalProperties": False,
+                },
+            },
+        },
+        "required": ["summary", "should_escalate", "judgments"],
+        "additionalProperties": False,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,58 @@
+from fastapi.testclient import TestClient
+
+from fmi_report_guard.api import app
+
+
+def test_health_reports_openai_config_state(monkeypatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    client = TestClient(app)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["openai_configured"] is False
+
+
+def test_judge_requires_openai_key(monkeypatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/judge",
+        json={
+            "candidate": {
+                "title": "Android Smartphone Market",
+                "estimated_year": 2026,
+                "estimated_value_usd_mn": 900000,
+                "forecast_year": 2036,
+                "forecast_value_usd_mn": 1690000,
+                "cagr_percent": 6.5,
+            },
+            "matches": [],
+        },
+    )
+
+    assert response.status_code == 503
+
+
+def test_judge_returns_without_model_call_when_no_matches(monkeypatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/judge",
+        json={
+            "candidate": {
+                "title": "Android Smartphone Market",
+                "estimated_year": 2026,
+                "estimated_value_usd_mn": 900000,
+                "forecast_year": 2036,
+                "forecast_value_usd_mn": 1690000,
+                "cagr_percent": 6.5,
+            },
+            "matches": [],
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["should_escalate"] is False

--- a/web/README.md
+++ b/web/README.md
@@ -27,13 +27,18 @@ On Render, the build downloads the ZIP into the static bundle so the browser loa
 
 The repo root contains `render.yaml`.
 
-Render settings:
+The Blueprint creates two services:
 
-- Root directory: `web`
-- Build command: `npm run fetch-db && npm run build`
-- Publish directory: `dist`
+- `fmi-benchmark-checker`: static frontend
+- `fmi-benchmark-api`: Python API that calls OpenAI
 
-The DB ZIP is not committed to Git. Render downloads it during build.
+Set this secret on `fmi-benchmark-api`, not on the static frontend:
+
+```text
+OPENAI_API_KEY
+```
+
+The DB ZIP is not committed to Git. Render downloads it during the frontend build.
 
 ## Check logic
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,7 +13,8 @@ import {
   Loader2,
   Search,
   ShieldAlert,
-  ShieldCheck
+  ShieldCheck,
+  Sparkles
 } from "lucide-react";
 
 type Unit = "USD million" | "USD billion";
@@ -46,6 +47,38 @@ type Match = {
 
 const DEFAULT_DB_URL =
   import.meta.env.VITE_BENCHMARK_DB_URL || "/fmi_global_benchmarks.sqlite.zip";
+const LLM_API_URL =
+  import.meta.env.VITE_LLM_API_URL || "http://127.0.0.1:8000";
+const LLM_MATCH_LIMIT = 12;
+
+type AiJudgment = {
+  market_name: string;
+  url: string;
+  relationship:
+    | "candidate_is_child"
+    | "candidate_is_parent"
+    | "sibling_or_adjacent"
+    | "unrelated"
+    | "unclear";
+  confidence: number;
+  violates_parent_child_rule: boolean;
+  issue: string;
+  control_f: string;
+  change_with: string;
+  reason: string;
+};
+
+type AiResult = {
+  summary: string;
+  should_escalate: boolean;
+  judgments: AiJudgment[];
+};
+
+type AiState =
+  | { status: "idle"; message: string }
+  | { status: "loading"; message: string }
+  | { status: "ready"; message: string; result: AiResult }
+  | { status: "error"; message: string };
 
 const STOPWORDS = new Set([
   "market",
@@ -289,6 +322,10 @@ function App() {
   const [unit2036, setUnit2036] = useState<Unit>("USD million");
   const [searchText, setSearchText] = useState("");
   const [copyState, setCopyState] = useState("Copy issues");
+  const [aiState, setAiState] = useState<AiState>({
+    status: "idle",
+    message: "AI brain not run yet."
+  });
 
   async function loadBytes(bytes: Uint8Array, source: string) {
     setDbState({ status: "loading", message: "Opening SQLite in browser..." });
@@ -355,6 +392,9 @@ function App() {
   }, [benchmarks, canCheck, candidate2026, candidate2036, cagrValue, title]);
 
   const issues = matches.filter((match) => match.issue);
+  const llmCandidateMatches = matches
+    .filter((match) => match.relation !== "self_check")
+    .slice(0, LLM_MATCH_LIMIT);
   const filteredMatches = matches.filter((match) => {
     if (!searchText.trim()) return true;
     const haystack = `${match.benchmark.marketName} ${match.benchmark.url} ${match.issue ?? ""}`.toLowerCase();
@@ -380,6 +420,81 @@ function App() {
     await navigator.clipboard.writeText(copyableIssues);
     setCopyState("Copied");
     window.setTimeout(() => setCopyState("Copy issues"), 1400);
+  }
+
+  async function askAiBrain() {
+    if (!canCheck || candidate2026 === null || candidate2036 === null) return;
+    if (!llmCandidateMatches.length) {
+      setAiState({
+        status: "ready",
+        message: "No benchmark candidates available for AI review.",
+        result: {
+          summary: "No likely parent-child benchmark candidates were found.",
+          should_escalate: false,
+          judgments: []
+        }
+      });
+      return;
+    }
+
+    try {
+      setAiState({
+        status: "loading",
+        message: `Sending ${llmCandidateMatches.length} likely matches to AI brain...`
+      });
+      const response = await fetch(`${LLM_API_URL.replace(/\/$/, "")}/api/judge`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          candidate: {
+            title: title.trim(),
+            estimated_year: 2026,
+            estimated_value_usd_mn: candidate2026,
+            forecast_year: 2036,
+            forecast_value_usd_mn: candidate2036,
+            cagr_percent: cagrValue
+          },
+          matches: llmCandidateMatches.map((match) => ({
+            relationship_hint:
+              match.relation === "candidate_subset"
+                ? "candidate may be child of benchmark"
+                : "candidate may be parent of benchmark",
+            issue_hint: match.issue ?? "",
+            recommendation_hint: match.recommendation ?? "",
+            benchmark: {
+              market_name: match.benchmark.marketName,
+              url: match.benchmark.url,
+              category: match.benchmark.category,
+              estimated_year: match.benchmark.estimatedYear,
+              estimated_value_usd_mn: match.benchmark.estimatedValueUsdMn,
+              forecast_year: match.benchmark.forecastYear,
+              forecast_value_usd_mn: match.benchmark.forecastValueUsdMn,
+              cagr_percent: match.benchmark.cagrPercent
+            }
+          }))
+        })
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(errorText || `AI API failed with ${response.status}`);
+      }
+
+      const result = (await response.json()) as AiResult;
+      setAiState({
+        status: "ready",
+        message: result.should_escalate ? "AI found likely true hierarchy issues." : "AI did not confirm a hard hierarchy issue.",
+        result
+      });
+    } catch (error) {
+      setAiState({
+        status: "error",
+        message:
+          error instanceof Error
+            ? error.message
+            : "AI brain request failed."
+      });
+    }
   }
 
   return (
@@ -511,7 +626,68 @@ function App() {
               <ClipboardCopy aria-hidden="true" />
               {copyState}
             </button>
+            <button className="ai-button" type="button" onClick={askAiBrain} disabled={!canCheck || aiState.status === "loading"}>
+              {aiState.status === "loading" ? <Loader2 className="spin" aria-hidden="true" /> : <Sparkles aria-hidden="true" />}
+              Ask AI brain
+            </button>
           </div>
+
+          <section className={`ai-panel ${aiState.status}`}>
+            <div className="ai-panel-head">
+              <Sparkles aria-hidden="true" />
+              <div>
+                <h3>AI relationship judgment</h3>
+                <p>{aiState.message}</p>
+              </div>
+            </div>
+            {aiState.status === "ready" && (
+              <div className="ai-results">
+                <p className="ai-summary">{aiState.result.summary}</p>
+                {aiState.result.judgments.length ? (
+                  <div className="ai-grid">
+                    {aiState.result.judgments.map((judgment, index) => (
+                      <article
+                        className={`ai-card ${judgment.violates_parent_child_rule ? "ai-issue" : ""}`}
+                        key={`${judgment.url || judgment.market_name}-${index}`}
+                      >
+                        <div className="ai-card-title">
+                          <strong>{judgment.market_name}</strong>
+                          <span>{judgment.relationship.replaceAll("_", " ")} · {(judgment.confidence * 100).toFixed(0)}%</span>
+                        </div>
+                        <p>{judgment.reason}</p>
+                        {judgment.violates_parent_child_rule && (
+                          <>
+                            <dl>
+                              <div>
+                                <dt>Issue</dt>
+                                <dd>{judgment.issue}</dd>
+                              </div>
+                              <div>
+                                <dt>Control+F</dt>
+                                <dd>{judgment.control_f}</dd>
+                              </div>
+                              <div>
+                                <dt>Change with</dt>
+                                <dd>{judgment.change_with}</dd>
+                              </div>
+                            </dl>
+                            {judgment.url && (
+                              <a href={judgment.url} target="_blank" rel="noreferrer">
+                                <LinkIcon aria-hidden="true" />
+                                Open benchmark
+                              </a>
+                            )}
+                          </>
+                        )}
+                      </article>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="ai-empty">No AI judgments returned.</p>
+                )}
+              </div>
+            )}
+          </section>
 
           <div className="table-wrap">
             <table>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -406,6 +406,154 @@ select {
   height: 16px;
 }
 
+.ai-button {
+  min-height: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: 0;
+  border-radius: 8px;
+  background: #153b6f;
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 800;
+  padding: 0 14px;
+  cursor: pointer;
+}
+
+.ai-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+.ai-button svg {
+  width: 16px;
+  height: 16px;
+}
+
+.ai-panel {
+  border-bottom: 1px solid #dfe5e7;
+  padding: 14px 16px;
+  background: #f9fbfc;
+}
+
+.ai-panel-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.ai-panel-head svg {
+  width: 19px;
+  height: 19px;
+  color: #153b6f;
+  margin-top: 2px;
+}
+
+.ai-panel h3 {
+  margin: 0;
+  font-size: 15px;
+}
+
+.ai-panel p {
+  margin: 3px 0 0;
+  color: #5d696c;
+  font-size: 13px;
+  line-height: 1.42;
+}
+
+.ai-panel.error {
+  background: #fff7ef;
+}
+
+.ai-panel.error .ai-panel-head svg,
+.ai-panel.error p {
+  color: #8a3c14;
+}
+
+.ai-results {
+  margin-top: 12px;
+}
+
+.ai-summary {
+  color: #1f2b2e;
+}
+
+.ai-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.ai-card {
+  border: 1px solid #dfe5e7;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 12px;
+}
+
+.ai-card.ai-issue {
+  border-color: #ebb48d;
+  background: #fffaf5;
+}
+
+.ai-card-title {
+  display: grid;
+  gap: 3px;
+}
+
+.ai-card-title strong {
+  font-size: 13px;
+}
+
+.ai-card-title span {
+  color: #647174;
+  font-size: 12px;
+  text-transform: capitalize;
+}
+
+.ai-card dl {
+  margin: 10px 0 0;
+  display: grid;
+  gap: 8px;
+}
+
+.ai-card dt {
+  color: #647174;
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.ai-card dd {
+  margin: 2px 0 0;
+  color: #7c360f;
+  font-size: 12px;
+  line-height: 1.42;
+}
+
+.ai-card a {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 10px;
+  color: #0f6c9c;
+  font-size: 12px;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.ai-card a svg {
+  width: 14px;
+  height: 14px;
+}
+
+.ai-empty {
+  color: #647174;
+}
+
 .table-wrap {
   overflow: auto;
   max-height: calc(100vh - 368px);
@@ -550,5 +698,9 @@ td a svg {
   .verdict {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .ai-grid {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- Add FastAPI backend service for OpenAI-backed parent/child market judgment
- Add Render Blueprint API service and static frontend API URL wiring
- Add Ask AI brain button and relationship judgment panel in the frontend
- Keep DB filtering in browser, send only top likely benchmark matches to the API

## Verification
- pytest
- npm run build
- code-review-graph detect-changes --brief